### PR TITLE
add very basic rpc test GHA

### DIFF
--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -1,16 +1,17 @@
-name: Run Testground
+name: RPC Test
 
 on:
   pull_request:
     paths: ["packages/nitro-rpc-client", ".github/workflows/rpc-test.yml"]
   workflow_dispatch:
 jobs:
-  run-testground:
+  run-rpc-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:
           go-version: "^1.20.0"
+
       - uses: actions/checkout@v3
 
       # Get go-nitro
@@ -20,9 +21,10 @@ jobs:
           path: "code/go-nitro"
       
       - name: Run go-nitro RPC server
-      - working-directory: code/go-nitro
-      - run: go run . &
+        run: go run . &
+        working-directory: code/go-nitro
+
 
       - name: Launch Address request using CLI tool and test against expectations
-      - working-directory: ./packages/nitro-rpc-client
-      - run: npm exec -c 'nitro-rpc-client addresss' | grep -q '0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE' || echo "did not find expected address" && exit 1
+        run: npm exec -c 'nitro-rpc-client addresss' | grep -q '0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE' || echo "did not find expected address" && exit 1
+        working-directory: ./packages/nitro-rpc-client

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -26,8 +26,7 @@ jobs:
 
 
       - name: Launch Address request using CLI tool and test against expectations
-        run: ./test-against-server.sh
-        shell: bash
+        run: bash ./test-against-server.sh
         working-directory: ./packages/nitro-rpc-client
 
       - name: Archive logs

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -1,0 +1,28 @@
+name: Run Testground
+
+on:
+  pull_request:
+    paths: ["packages/nitro-rpc-client", ".github/workflows/rpc-test.yml"]
+  workflow_dispatch:
+jobs:
+  run-testground:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "^1.20.0"
+      - uses: actions/checkout@v3
+
+      # Get go-nitro
+      - uses: actions/checkout@v3
+        with:
+          repository: "statechannels/go-nitro"
+          path: "code/go-nitro"
+      
+      - name: Run go-nitro RPC server
+      - working-directory: code/go-nitro
+      - run: go run . &
+
+      - name: Launch Address request using CLI tool and test against expectations
+      - working-directory: ./packages/nitro-rpc-client
+      - run: npm exec -c 'nitro-rpc-client addresss' | grep -q '0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE' || echo "did not find expected address" && exit 1

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -24,6 +24,8 @@ jobs:
         run: go run . &> output.log &
         working-directory: code/go-nitro
 
+      - name: Install dependencies
+        run: yarn ci
 
       - name: Launch Address request using CLI tool and test against expectations
         run: bash ./test-against-server.sh

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -14,16 +14,23 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      # Install foundry so we can use it to run a chain instance
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       # Get go-nitro
       - uses: actions/checkout@v3
         with:
           repository: "statechannels/go-nitro"
           path: "code/go-nitro"
-      
+
+        # Start up a chain for the RPC server to work against
+      - name: Run anvil chain
+        run: anvil --host 0.0.0.0 --chain-id 1337 &
+
       - name: Run go-nitro RPC server
         run: go run . &> output.log &
         working-directory: code/go-nitro
-
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -24,6 +24,10 @@ jobs:
           repository: "statechannels/go-nitro"
           path: "code/go-nitro"
 
+      - name: Tidy
+        run: go mod tidy
+        working-directory: code/go-nitro
+
         # Start up a chain for the RPC server to work against
       - name: Run anvil chain
         run: anvil --host 0.0.0.0 --chain-id 1337 &

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -8,24 +8,22 @@ jobs:
   run-rpc-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
-        with:
-          repository: "statechannels/go-nitro"
-          path: "code/go-nitro"
       - uses: actions/setup-go@v3
         with:
           go-version: "^1.20.0"
-
       - uses: actions/setup-node@v3
-        with:
-          cache: "yarn"
+      - uses: actions/checkout@v3
 
       # Install foundry so we can use it to run a chain instance
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
       # Get go-nitro
+      - uses: actions/checkout@v3
+        with:
+          repository: "statechannels/go-nitro"
+          path: "code/go-nitro"
+
       - name: Tidy
         run: go mod tidy
         working-directory: code/go-nitro

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: "^1.20.0"
-
+      - uses: actions/setup-node@v3
       - uses: actions/checkout@v3
 
       # Install foundry so we can use it to run a chain instance

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -8,22 +8,24 @@ jobs:
   run-rpc-test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: "statechannels/go-nitro"
+          path: "code/go-nitro"
       - uses: actions/setup-go@v3
         with:
           go-version: "^1.20.0"
+
       - uses: actions/setup-node@v3
-      - uses: actions/checkout@v3
+        with:
+          cache: "yarn"
 
       # Install foundry so we can use it to run a chain instance
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
       # Get go-nitro
-      - uses: actions/checkout@v3
-        with:
-          repository: "statechannels/go-nitro"
-          path: "code/go-nitro"
-
       - name: Tidy
         run: go mod tidy
         working-directory: code/go-nitro

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -26,5 +26,6 @@ jobs:
 
 
       - name: Launch Address request using CLI tool and test against expectations
-        run: npm exec -c 'nitro-rpc-client addresss' | grep -q '0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE' || echo "did not find expected address" && exit 1
+        run: test-against-server.sh
+        shell: bash
         working-directory: ./packages/nitro-rpc-client

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -24,8 +24,9 @@ jobs:
         run: go run . &> output.log &
         working-directory: code/go-nitro
 
+
       - name: Install dependencies
-        run: yarn ci
+        run: yarn
 
       - name: Launch Address request using CLI tool and test against expectations
         run: bash ./test-against-server.sh

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -21,11 +21,18 @@ jobs:
           path: "code/go-nitro"
       
       - name: Run go-nitro RPC server
-        run: go run . &
+        run: go run . &> output.log &
         working-directory: code/go-nitro
 
 
       - name: Launch Address request using CLI tool and test against expectations
-        run: test-against-server.sh
+        run: ./test-against-server.sh
         shell: bash
         working-directory: ./packages/nitro-rpc-client
+
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: ./**/*.log

--- a/packages/nitro-rpc-client/test-against-server.sh
+++ b/packages/nitro-rpc-client/test-against-server.sh
@@ -1,0 +1,10 @@
+set -e
+
+output=$(npm exec -c 'nitro-rpc-client address')
+echo $output
+
+if echo $output | grep -q '0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE' ; then
+    echo "got expected address" && exit 0
+else
+    echo "did not get expected address" && exit 1
+fi

--- a/packages/nitro-rpc-client/test-against-server.sh
+++ b/packages/nitro-rpc-client/test-against-server.sh
@@ -3,6 +3,8 @@ set -e
 output=$(npm exec -c 'nitro-rpc-client address')
 echo $output
 
+echo $output > client-output.log
+
 if echo $output | grep -q '0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE' ; then
     echo "got expected address" && exit 0
 else


### PR DESCRIPTION
Fixes #5 

This isn't perfect but I think worth having in the short term. It is failing "correctly" now due to an actual incompatibility https://github.com/statechannels/go-nitro/pull/1252 .

Comment: there is a race condition in starting up go-nitro RPC server and then using the client. I think we should be OK because the former only takes a second or two and the latter is delayed by installing dependencies (takes around a minute). 

Question (possibly related) : I set it up so that the go-nitro logs get uploaded. But the output seems somewhat incomplete:

```log
go: downloading github.com/ethereum/go-ethereum v1.11.4
go: downloading github.com/rs/zerolog v1.28.0
go: downloading github.com/tidwall/buntdb v1.2.10
go: downloading github.com/mattn/go-colorable v0.1.13
go: downloading github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
go: downloading github.com/miguelmota/go-ethereum-hdwallet v0.1.1
go: downloading github.com/libp2p/go-libp2p v0.27.0
go: downloading github.com/multiformats/go-multiaddr v0.9.0
go: downloading github.com/nats-io/nats-server/v2 v2.9.10
go: downloading github.com/nats-io/nats.go v1.21.0
go: downloading nhooyr.io/websocket v1.8.7
go: downloading github.com/tidwall/btree v1.6.0
go: downloading github.com/tidwall/gjson v1.14.4
go: downloading github.com/tidwall/grect v0.1.4
go: downloading github.com/tidwall/match v1.1.1
go: downloading github.com/tidwall/rtred v0.1.2
go: downloading github.com/mattn/go-isatty v0.0.18
go: downloading github.com/google/go-cmp v0.5.9
go: downloading golang.org/x/crypto v0.7.0
go: downloading github.com/btcsuite/btcd v0.21.0-beta
go: downloading github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
go: downloading github.com/tyler-smith/go-bip39 v1.1.0
go: downloading github.com/multiformats/go-multiaddr-dns v0.3.1
go: downloading github.com/prometheus/client_golang v1.14.0
go: downloading go.uber.org/fx v1.19.2
go: downloading github.com/ipfs/go-cid v0.4.1
go: downloading github.com/mr-tron/base58 v1.2.0
go: downloading github.com/multiformats/go-multicodec v0.8.1
go: downloading github.com/multiformats/go-multihash v0.2.1
go: downloading google.golang.org/protobuf v1.30.0
go: downloading github.com/multiformats/go-multistream v0.4.1
go: downloading github.com/ipfs/go-log/v2 v2.5.1
go: downloading github.com/libp2p/zeroconf/v2 v2.2.0
go: downloading github.com/libp2p/go-reuseport v0.2.0
go: downloading github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd
go: downloading github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b
go: downloading github.com/multiformats/go-multiaddr-fmt v0.1.0
go: downloading github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
go: downloading github.com/minio/sha256-simd v1.0.0
go: downloading github.com/multiformats/go-multibase v0.2.0
go: downloading github.com/multiformats/go-varint v0.0.7
go: downloading github.com/nats-io/nkeys v0.3.0
go: downloading github.com/nats-io/nuid v1.0.1
go: downloading github.com/klauspost/compress v1.16.4
go: downloading github.com/tidwall/pretty v1.2.1
go: downloading golang.org/x/sys v0.7.0
go: downloading github.com/deckarep/golang-set/v2 v2.1.0
go: downloading github.com/fsnotify/fsnotify v1.6.0
go: downloading github.com/google/uuid v1.3.0
go: downloading github.com/go-stack/stack v1.8.1
go: downloading github.com/edsrzf/mmap-go v1.0.0
go: downloading github.com/holiman/uint256 v1.2.0
go: downloading github.com/gofrs/flock v0.8.1
go: downloading github.com/golang/snappy v0.0.4
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading github.com/gorilla/websocket v1.5.0
go: downloading golang.org/x/exp v0.0.0-20230321023759-10a507213a29
go: downloading github.com/VictoriaMetrics/fastcache v1.6.0
go: downloading github.com/holiman/bloomfilter/v2 v2.0.3
go: downloading github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
go: downloading github.com/minio/highwayhash v1.0.2
go: downloading github.com/nats-io/jwt/v2 v2.3.0
go: downloading golang.org/x/time v0.0.0-20220922220347-f3bd1da661af
go: downloading github.com/quic-go/quic-go v0.33.0
go: downloading github.com/libp2p/go-flow-metrics v0.1.0
go: downloading github.com/libp2p/go-msgio v0.3.0
go: downloading golang.org/x/sync v0.1.0
go: downloading github.com/libp2p/go-netroute v0.2.1
go: downloading github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
go: downloading github.com/libp2p/go-yamux/v4 v4.0.0
go: downloading github.com/benbjohnson/clock v1.3.0
go: downloading github.com/raulk/go-watchdog v1.3.0
go: downloading github.com/jbenet/go-temp-err-catcher v0.1.0
go: downloading github.com/libp2p/go-buffer-pool v0.1.0
go: downloading github.com/libp2p/go-libp2p-asn-util v0.3.0
go: downloading github.com/flynn/noise v1.0.0
go: downloading github.com/google/gopacket v1.1.19
go: downloading github.com/quic-go/webtransport-go v0.5.2
go: downloading github.com/miekg/dns v1.1.53
go: downloading github.com/beorn7/perks v1.0.1
go: downloading github.com/cespare/xxhash/v2 v2.2.0
go: downloading github.com/golang/protobuf v1.5.3
go: downloading github.com/prometheus/client_model v0.3.0
go: downloading github.com/prometheus/common v0.42.0
go: downloading github.com/prometheus/procfs v0.9.0
go: downloading go.uber.org/dig v1.16.1
go: downloading go.uber.org/multierr v1.11.0
go: downloading go.uber.org/zap v1.24.0
go: downloading golang.org/x/net v0.8.0
go: downloading github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc
go: downloading github.com/klauspost/cpuid/v2 v2.2.4
go: downloading github.com/multiformats/go-base32 v0.1.0
go: downloading github.com/multiformats/go-base36 v0.2.0
go: downloading github.com/tidwall/tinyqueue v0.1.1
go: downloading github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
go: downloading github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
go: downloading github.com/mattn/go-runewidth v0.0.9
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/tklauser/go-sysconf v0.3.5
go: downloading github.com/libp2p/go-nat v0.1.0
go: downloading github.com/containerd/cgroups v1.1.0
go: downloading github.com/elastic/gosigar v0.14.2
go: downloading github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c
go: downloading github.com/libp2p/go-cidranger v1.1.0
go: downloading github.com/francoispqt/gojay v1.2.13
go: downloading github.com/quic-go/qpack v0.4.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.4
go: downloading go.uber.org/atomic v1.10.0
go: downloading github.com/cockroachdb/errors v1.9.1
go: downloading github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
go: downloading github.com/cockroachdb/redact v1.1.3
go: downloading github.com/status-im/keycard-go v0.2.0
go: downloading golang.org/x/text v0.8.0
go: downloading github.com/huin/goupnp v1.1.0
go: downloading github.com/jackpal/go-nat-pmp v1.0.2
go: downloading github.com/koron/go-ssdp v0.0.4
go: downloading github.com/tklauser/numcpus v0.2.2
go: downloading github.com/coreos/go-systemd/v22 v22.5.0
go: downloading github.com/docker/go-units v0.5.0
go: downloading github.com/godbus/dbus/v5 v5.1.0
go: downloading github.com/opencontainers/runtime-spec v1.0.2
go: downloading github.com/quic-go/qtls-go1-20 v0.2.2
go: downloading lukechampine.com/blake3 v1.1.7
go: downloading github.com/spaolacci/murmur3 v1.1.0
go: downloading github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b
go: downloading github.com/getsentry/sentry-go v0.18.0
go: downloading github.com/DataDog/zstd v1.5.2
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading github.com/kr/pretty v0.3.1
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/kr/text v0.2.0
go: downloading github.com/rogpeppe/go-internal v1.9.0

```