### PR TITLE
Do not pass in * as a origin

### DIFF
--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -9,7 +9,7 @@ export class HttpTransport {
 
   public static async createTransport(server: string): Promise<Transport> {
     // eslint-disable-next-line new-cap
-    const ws = new w3cwebsocket(`ws://${server}/subscribe`, undefined, '*');
+    const ws = new w3cwebsocket(`ws://${server}/subscribe`, undefined);
     // Wait for onopen to fire so we know the connection is ready
     await new Promise<void>((resolve) => (ws.onopen = () => resolve()));
 


### PR DESCRIPTION
Previously we were hardcoding * as the origin for our websocket connection. This caused issues with the go-nitro rpc rejecting the websocket due to the origin not matching the url the connection was coming from (seen in https://github.com/statechannels/go-nitro/pull/1252).

This PR removes specifying a hardcoded origin to use, instead it lets the underlying websocket library determine the correct origin.

 