### PR TITLE
Lint config cleanups

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 /* global module */
 module.exports = {
+  root: true,
   ignorePatterns: [
     "!.prettierrc.js",
     "**/!.eslintrc.js",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript",
+    "plugin:@typescript-eslint/recommended",
   ],
   rules: {
     "no-self-compare": "error",
@@ -42,15 +43,4 @@ module.exports = {
       },
     ],
   },
-  overrides: [
-    {
-      files: ["**/*.ts"],
-      extends: ["plugin:@typescript-eslint/recommended"],
-      rules: {},
-    },
-    {
-      files: ["./src/**/*.ts"],
-      rules: {},
-    },
-  ],
 };

--- a/packages/site/.eslintrc.cjs
+++ b/packages/site/.eslintrc.cjs
@@ -5,7 +5,6 @@ module.exports = {
     es2020: true,
   },
   extends: [
-    "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react-hooks/recommended",
     "plugin:storybook/recommended",

--- a/packages/site/.eslintrc.cjs
+++ b/packages/site/.eslintrc.cjs
@@ -4,12 +4,7 @@ module.exports = {
     browser: true,
     es2020: true,
   },
-  extends: [
-    "plugin:@typescript-eslint/recommended",
-    "plugin:react-hooks/recommended",
-    "plugin:storybook/recommended",
-  ],
-  parser: "@typescript-eslint/parser",
+  extends: ["plugin:react-hooks/recommended", "plugin:storybook/recommended"],
   parserOptions: {
     ecmaVersion: "latest",
     sourceType: "module",

--- a/packages/site/.eslintrc.cjs
+++ b/packages/site/.eslintrc.cjs
@@ -1,16 +1,22 @@
+/* global module */
 module.exports = {
   env: {
     browser: true,
-    es2020: true
+    es2020: true,
   },
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'plugin:storybook/recommended'],
-  parser: '@typescript-eslint/parser',
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:storybook/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
   parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module'
+    ecmaVersion: "latest",
+    sourceType: "module",
   },
-  plugins: ['react-refresh'],
+  plugins: ["react-refresh"],
   rules: {
-    'react-refresh/only-export-components': 'warn'
-  }
+    "react-refresh/only-export-components": "warn",
+  },
 };


### PR DESCRIPTION
This PR:
- Adds `root: true` to the top level eslint config.
- Removes eslint settings from `site` package that are redundant with root config.
- Removes  `overrides` settings. It doesn't seem like these are needed.