### PR TITLE
Lint includes package root

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && vite build",
     "build-storybook": "storybook build",
     "dev": "vite",
-    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext js,jsx,cjs,ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006"
   },

--- a/packages/site/vite.config.ts
+++ b/packages/site/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});


### PR DESCRIPTION
This PR addresses https://github.com/statechannels/nitro-gui/pull/23#discussion_r1189928197. Previously, we were not linting javascript files or files outside of `src`