### PR TITLE
Fix `run-rpc-test` CI action to work with the latest go-nitro

### DIFF
--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -34,7 +34,7 @@ jobs:
         # TODO: We currently pass in a zeroed address for the adjudicator
         # If we want to test further functionality we should deploy the adjudicator and pass the address in
       - name: Run go-nitro RPC server
-        run: go run . -naaddress 0x0000000000000000000000000000000000000000 &> output.log &
+        run: go run . -naaddress 0x0000000000000000000000000000000000000000 -config ./scripts/test-configs/alice.toml &> output.log &
         working-directory: code/go-nitro
 
       - name: Install dependencies

--- a/.github/workflows/rpc-test.yml
+++ b/.github/workflows/rpc-test.yml
@@ -31,9 +31,10 @@ jobs:
         # Start up a chain for the RPC server to work against
       - name: Run anvil chain
         run: anvil --host 0.0.0.0 --chain-id 1337 &
-
+        # TODO: We currently pass in a zeroed address for the adjudicator
+        # If we want to test further functionality we should deploy the adjudicator and pass the address in
       - name: Run go-nitro RPC server
-        run: go run . &> output.log &
+        run: go run . -naaddress 0x0000000000000000000000000000000000000000 &> output.log &
         working-directory: code/go-nitro
 
       - name: Install dependencies


### PR DESCRIPTION
With recent changes to `go-nitro` the `-naaddress` and `-config`(or `-pk` and `-chainPk`) are now required. This PR updates our CI to pass in Alice's test config file as well as specify a zero address for the adjudicator.  The zeroed adjudicator address should  be good enough for now, since we're only calling `address` on the RPC client. 