### PR TITLE
Use a "refresh" pattern for changing rpcUrl

### DIFF
--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -7,10 +7,9 @@ import TopBar from "./components/TopBar";
 import { QUERY_KEY } from "./constants";
 
 function App() {
-  const [url, _] = useState(
+  const url =
     new URLSearchParams(window.location.search).get(QUERY_KEY) ??
-      "localhost:4005"
-  );
+    "localhost:4005";
   const [nitroClient, setNitroClient] = useState<NitroRpcClient | null>(null);
   const [version, setVersion] = useState("");
   const [address, setAddress] = useState("");

--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -4,9 +4,13 @@ import { NitroRpcClient } from "@statechannels/nitro-rpc-client";
 import { NetworkBalance } from "./components/NetworkBalance";
 import "./App.css";
 import TopBar from "./components/TopBar";
+import { QUERY_KEY } from "./constants";
 
 function App() {
-  const [url, setUrl] = useState("localhost:4005");
+  const [url, _] = useState(
+    new URLSearchParams(window.location.search).get(QUERY_KEY) ??
+      "localhost:4005"
+  );
   const [nitroClient, setNitroClient] = useState<NitroRpcClient | null>(null);
   const [version, setVersion] = useState("");
   const [address, setAddress] = useState("");
@@ -24,7 +28,7 @@ function App() {
 
   return (
     <>
-      <TopBar url={url} setUrl={setUrl} />
+      <TopBar url={url} />
       <div style={{ display: "flex", justifyContent: "space-around" }}>
         <div className="card">
           <NetworkBalance

--- a/packages/site/src/components/RpcConnect.stories.tsx
+++ b/packages/site/src/components/RpcConnect.stories.tsx
@@ -11,9 +11,6 @@ export default meta;
 
 type Story = StoryObj<typeof RpcConnect>;
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const setUrl = function (_url: string) {};
-
 export const Primary: Story = {
-  render: () => <RpcConnect url="localhost:8545" setUrl={setUrl} />,
+  render: () => <RpcConnect url="localhost:8545" />,
 };

--- a/packages/site/src/components/RpcConnect.tsx
+++ b/packages/site/src/components/RpcConnect.tsx
@@ -3,29 +3,27 @@ import TextField from "@mui/material/TextField";
 import React, { useState } from "react";
 import Typography from "@mui/material/Typography";
 
+import { QUERY_KEY } from "../constants";
+
 export type RPCConnectProps = {
   url: string;
-  setUrl: (url: string) => void;
 };
 
-export default function RpcConnect({ url, setUrl }: RPCConnectProps) {
+export default function RpcConnect({ url }: RPCConnectProps) {
   const [urlToEdit, setUrlToEdit] = useState(url);
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     setUrlToEdit(e.target.value);
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setUrl(urlToEdit);
-  };
-
   return (
-    <form
-      style={{ display: "flex", alignItems: "center" }}
-      onSubmit={handleSubmit}
-    >
+    <form style={{ display: "flex", alignItems: "center" }}>
       <Typography display="inline">Nitro RPC Connect:</Typography>
-      <TextField sx={{ ml: 2 }} value={urlToEdit} onChange={handleChange} />
+      <TextField
+        sx={{ ml: 2 }}
+        name={QUERY_KEY}
+        value={urlToEdit}
+        onChange={handleChange}
+      />
       <Button type="submit" sx={{ ml: 2 }} variant="contained">
         Connect
       </Button>

--- a/packages/site/src/constants.ts
+++ b/packages/site/src/constants.ts
@@ -1,0 +1,1 @@
+export const QUERY_KEY = "rpcUrl";


### PR DESCRIPTION
I suppose the downside of this is it may trigger unecessary requests to the GUI server. 

Otherwise: 

* all state is wiped (which makes sense)
* visible "refresh" to the user is clunky but actually a decent visual indicator that something fairly drastic just happened
the query param option makes it potentially even easier to programmatically spin up multiple tabs pointing at different rpc servers
