### PR TITLE
Address linter warning

### DIFF
--- a/packages/nitro-rpc-client/package.json
+++ b/packages/nitro-rpc-client/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
-    "lint:eslint": "eslint . --cache --ext js,ts",
+    "lint:eslint": "eslint . --cache --ext js,ts --max-warnings 0",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
     "start": "npx ts-node src/cli.ts"

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -123,8 +123,7 @@ yargs(hideBin(process.argv))
   .strict()
   .parse();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getRandomElement(col: any[]) {
+function getRandomElement<T>(col: T[]): T {
   return col[Math.floor(Math.random() * col.length)];
 }
 async function wait(ms: number) {


### PR DESCRIPTION
Fixes #35 

This PR:
- Updates the `nitro-rpc-client` linting to fail on any warnings
- Resolves a linter warning