### PR TITLE
Add additional query functions to rpc client

### DIFF
--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -6,7 +6,11 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { NitroRpcClient } from "../src/rpc-client";
-import { getLocalRPCUrl, logOutChannelUpdates } from "../src/utils";
+import {
+  compactJson,
+  getLocalRPCUrl,
+  logOutChannelUpdates,
+} from "../src/utils";
 
 yargs(hideBin(process.argv))
   .scriptName("client-runner")
@@ -180,7 +184,4 @@ async function wait(ms: number) {
 
 function getChannelIdFromObjectiveId(objectiveId: string): string {
   return objectiveId.split("-")[1];
-}
-export function compactJson(obj: unknown): string {
-  return JSON.stringify(obj, null, 0);
 }

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -31,7 +31,7 @@ yargs(hideBin(process.argv))
         getLocalRPCUrl(4007)
       );
 
-      for (const client of [aliceClient]) {
+      for (const client of [aliceClient, ireneClient, bobClient]) {
         const ledgers = await client.GetAllLedgerChannels();
 
         console.log(

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -6,7 +6,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 
 import { NitroRpcClient } from "./rpc-client";
-import { getLocalRPCUrl, logOutChannelUpdates } from "./utils";
+import { compactJson, getLocalRPCUrl, logOutChannelUpdates } from "./utils";
 
 yargs(hideBin(process.argv))
   .scriptName("nitro-rpc-client")
@@ -51,6 +51,52 @@ yargs(hideBin(process.argv))
       process.exit(0);
     }
   )
+  .command(
+    "get-all-ledger-channels",
+    "Get all ledger channels",
+    async () => {},
+    async (yargs) => {
+      const rpcPort = yargs.p;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getLocalRPCUrl(rpcPort)
+      );
+      const ledgers = await rpcClient.GetAllLedgerChannels();
+      for (const ledger of ledgers) {
+        console.log(`${compactJson(ledger)}`);
+      }
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+  .command(
+    "get-payment-channels-by-ledger <ledgerId>",
+    "Gets any payment channels funded by the given ledger",
+    (yargsBuilder) => {
+      return yargsBuilder.positional("ledgerId", {
+        describe: "The id of the ledger channel to defund",
+        type: "string",
+        demandOption: true,
+      });
+    },
+
+    async (yargs) => {
+      const rpcPort = yargs.p;
+
+      const rpcClient = await NitroRpcClient.CreateHttpNitroClient(
+        getLocalRPCUrl(rpcPort)
+      );
+      const paymentChans = await rpcClient.GetPaymentChannelsByLedger(
+        yargs.ledgerId
+      );
+      for (const p of paymentChans) {
+        console.log(`${compactJson(p)}`);
+      }
+      await rpcClient.Close();
+      process.exit(0);
+    }
+  )
+
   .command(
     "direct-fund <counterparty>",
     "Creates a directly funded ledger channel",

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -166,6 +166,14 @@ export class NitroRpcClient {
   }
 
   /**
+   * GetAllLedgerChannels queries the RPC server for all ledger channels.
+   * @returns A `LedgerChannelInfo` object containing the channel's information for each ledger channel
+   */
+  public async GetAllLedgerChannels(): Promise<LedgerChannelInfo[]> {
+    return this.sendRequest("get_all_ledger_channels", {});
+  }
+
+  /**
    * GetPaymentChannel queries the RPC server for a payment channel.
    *
    * @param channelId - The ID of the channel to query for
@@ -175,6 +183,19 @@ export class NitroRpcClient {
     channelId: string
   ): Promise<PaymentChannelInfo> {
     return this.sendRequest("get_payment_channel", { Id: channelId });
+  }
+  /**
+   * GetPaymentChannelsByLedger queries the RPC server for any payment channels that are actively funded by the given ledger.
+   *
+   * @param ledgerId - The ID of the ledger to find payment channels for
+   * @returns A `PaymentChannelInfo` object containing the channel's information for each payment channel
+   */
+  public async GetPaymentChannelsByLedger(
+    ledgerId: string
+  ): Promise<PaymentChannelInfo[]> {
+    return this.sendRequest("get_payment_channels_by_ledger", {
+      LedgerId: ledgerId,
+    });
   }
 
   async sendRequest<K extends RequestMethod>(

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -53,6 +53,10 @@ export type PaymentParams = {
 type GetChannelRequest = {
   Id: string;
 };
+
+type GetByLedgerRequest = {
+  LedgerId: string;
+};
 export type DefundObjectiveRequest = {
   ChannelId: string;
 };
@@ -78,10 +82,19 @@ export type GetLedgerChannelRequest = JsonRpcRequest<
   "get_ledger_channel",
   GetChannelRequest
 >;
+export type GetAllLedgerChannelsRequest = JsonRpcRequest<
+  "get_all_ledger_channels",
+  Record<string, never>
+>;
 export type GetPaymentChannelRequest = JsonRpcRequest<
   "get_payment_channel",
   GetChannelRequest
 >;
+export type GetPaymentChannelsByLedgerRequest = JsonRpcRequest<
+  "get_payment_channels_by_ledger",
+  GetByLedgerRequest
+>;
+
 export type VersionRequest = JsonRpcRequest<"version", Record<string, never>>;
 export type DirectDefundRequest = JsonRpcRequest<
   "direct_defund",
@@ -104,6 +117,10 @@ export type GetAddressResponse = JsonRpcResponse<string>;
 export type DirectFundResponse = JsonRpcResponse<ObjectiveResponse>;
 export type DirectDefundResponse = JsonRpcResponse<string>;
 export type VirtualDefundResponse = JsonRpcResponse<string>;
+export type GetAllLedgerChannelsResponse = JsonRpcResponse<LedgerChannelInfo[]>;
+export type GetPaymentChannelsByLedgerResponse = JsonRpcResponse<
+  PaymentChannelInfo[]
+>;
 
 /**
  * RPC Request/Response map
@@ -119,6 +136,14 @@ export type RPCRequestAndResponses = {
   get_payment_channel: [GetPaymentChannelRequest, GetPaymentChannelResponse];
   pay: [PaymentRequest, PaymentResponse];
   virtual_defund: [VirtualDefundRequest, VirtualDefundResponse];
+  get_all_ledger_channels: [
+    GetAllLedgerChannelsRequest,
+    GetAllLedgerChannelsResponse
+  ];
+  get_payment_channels_by_ledger: [
+    GetPaymentChannelsByLedgerRequest,
+    GetPaymentChannelsByLedgerResponse
+  ];
 };
 
 export type RequestMethod = keyof RPCRequestAndResponses;

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -109,3 +109,6 @@ export async function logOutChannelUpdates(rpcClient: NitroRpcClient) {
 function prettyJson(obj: unknown): string {
   return JSON.stringify(obj, null, 2);
 }
+export function compactJson(obj: unknown): string {
+  return JSON.stringify(obj, null, 0);
+}


### PR DESCRIPTION
This adds the two new functions that were added to the RPC API:
- `GetAllLedgerChannels`
- `GetPaymentChannelsByLedger`

I've added a simple script to print out the channel information that uses these new API functions to print out the existing channels in each client.

**Note**: This depends on https://github.com/statechannels/go-nitro/pull/1286