### PR TITLE
Fetch ledger channels from nitro node

### DIFF
--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { NitroRpcClient } from "@statechannels/nitro-rpc-client";
+import { LedgerChannelInfo } from "@statechannels/nitro-rpc-client/src/types";
 
 import "./App.css";
 import TopBar from "./components/TopBar";
@@ -7,18 +8,6 @@ import { QUERY_KEY } from "./constants";
 import PaymentChannelList from "./components/PaymentChannelList";
 import PaymentChannelDetails from "./components/PaymentChannelDetails";
 import LedgerChannelDetails from "./components/LedgerChannelDetails";
-
-const ledgerChannels = [
-  {
-    ID: "0x9823fa3d37ec304f90d1bef2c03c1fc70f86b6417f022d5e9ab88902a874f0cc",
-  },
-  {
-    ID: "0x06a508ca629080f81954bb4dcce6b71f1d8de0dded88d333c720d3b9d4067af0",
-  },
-  {
-    ID: "0x06a508ca629080f81954bb4dcce6b71f1d8de0dded88d333c720d3b9d4067af1",
-  },
-];
 
 const paymentChannels = [
   {
@@ -39,6 +28,7 @@ function App() {
   const [nitroClient, setNitroClient] = useState<NitroRpcClient | null>(null);
   const [version, setVersion] = useState("");
   const [address, setAddress] = useState("");
+  const [ledgerChannels, setLedgerChannels] = useState<LedgerChannelInfo[]>([]);
   const [focusedLedgerChannel, setFocusedLedgerChannel] = useState<string>(
     "0x9823fa3d37ec304f90d1bef2c03c1fc70f86b6417f022d5e9ab88902a874f0cc"
   );
@@ -55,6 +45,7 @@ function App() {
     if (nitroClient) {
       nitroClient.GetVersion().then((v) => setVersion(v));
       nitroClient.GetAddress().then((a) => setAddress(a));
+      nitroClient.GetAllLedgerChannels().then((l) => setLedgerChannels(l));
     }
   }, [nitroClient]);
 


### PR DESCRIPTION
This PR enables us to try fetching ledger channels from a nitro node. This is currently not working. To test:
1. Spin up nitro nodes in go-nitro using `go run ./scripts/start-rpc-servers.go`
2. Create a ledger channel using `npm exec -c 'nitro-rpc-client direct-fund 0xaaa6628ec44a8a742987ef3a114ddfe2d4f7adce'`
3. Load the dashboard.
4. Observe error logs on the nitro node.