### PR TITLE
Fetch payment channels from RPC node

### DIFF
--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -29,9 +29,7 @@ function App() {
   const [version, setVersion] = useState("");
   const [address, setAddress] = useState("");
   const [ledgerChannels, setLedgerChannels] = useState<LedgerChannelInfo[]>([]);
-  const [focusedLedgerChannel, setFocusedLedgerChannel] = useState<string>(
-    "0x9823fa3d37ec304f90d1bef2c03c1fc70f86b6417f022d5e9ab88902a874f0cc"
-  );
+  const [focusedLedgerChannel, setFocusedLedgerChannel] = useState<string>("");
 
   const [focusedPaymentChannel, setFocusedPaymentChannel] = useState<string>(
     "0x9823fa3d37ec304f90d1bef2c03c1fc70f86b6417f022d5e9ab88902a874f0cc"

--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -13,8 +13,6 @@ function App() {
     new URLSearchParams(window.location.search).get(QUERY_KEY) ??
     "localhost:4005";
   const [nitroClient, setNitroClient] = useState<NitroRpcClient | null>(null);
-  const [version, setVersion] = useState("");
-  const [address, setAddress] = useState("");
   const [ledgerChannels, setLedgerChannels] = useState<LedgerChannelInfo[]>([]);
   const [focusedLedgerChannel, setFocusedLedgerChannel] = useState<string>("");
 
@@ -24,8 +22,6 @@ function App() {
 
   useEffect(() => {
     if (nitroClient) {
-      nitroClient.GetVersion().then((v) => setVersion(v));
-      nitroClient.GetAddress().then((a) => setAddress(a));
       nitroClient.GetAllLedgerChannels().then((l) => {
         setLedgerChannels(l);
         if (l.length > 0) {
@@ -44,7 +40,10 @@ function App() {
         setFocusedLedgerChannel={setFocusedLedgerChannel}
       />
       <div style={{ display: "flex", justifyContent: "space-around" }}>
-        <LedgerChannelDetails version={version} url={url} address={address} />
+        <LedgerChannelDetails
+          nitroClient={nitroClient}
+          channelId={focusedLedgerChannel}
+        />
         <PaymentChannelContainer
           nitroClient={nitroClient}
           ledgerChannel={focusedLedgerChannel}

--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -5,21 +5,8 @@ import { LedgerChannelInfo } from "@statechannels/nitro-rpc-client/src/types";
 import "./App.css";
 import TopBar from "./components/TopBar";
 import { QUERY_KEY } from "./constants";
-import PaymentChannelList from "./components/PaymentChannelList";
-import PaymentChannelDetails from "./components/PaymentChannelDetails";
 import LedgerChannelDetails from "./components/LedgerChannelDetails";
-
-const paymentChannels = [
-  {
-    ID: "0x9823fa3d37ec304f90d1bef2c03c1fc70f86b6417f022d5e9ab88902a874f0cc",
-  },
-  {
-    ID: "0x06a508ca629080f81954bb4dcce6b71f1d8de0dded88d333c720d3b9d4067af0",
-  },
-  {
-    ID: "0x06a508ca629080f81954bb4dcce6b71f1d8de0dded88d333c720d3b9d4067af1",
-  },
-];
+import PaymentChannelContainer from "./components/PaymentChannelContainer";
 
 function App() {
   const url =
@@ -31,10 +18,6 @@ function App() {
   const [ledgerChannels, setLedgerChannels] = useState<LedgerChannelInfo[]>([]);
   const [focusedLedgerChannel, setFocusedLedgerChannel] = useState<string>("");
 
-  const [focusedPaymentChannel, setFocusedPaymentChannel] = useState<string>(
-    "0x9823fa3d37ec304f90d1bef2c03c1fc70f86b6417f022d5e9ab88902a874f0cc"
-  );
-
   useEffect(() => {
     NitroRpcClient.CreateHttpNitroClient(url).then((c) => setNitroClient(c));
   }, [url]);
@@ -43,7 +26,12 @@ function App() {
     if (nitroClient) {
       nitroClient.GetVersion().then((v) => setVersion(v));
       nitroClient.GetAddress().then((a) => setAddress(a));
-      nitroClient.GetAllLedgerChannels().then((l) => setLedgerChannels(l));
+      nitroClient.GetAllLedgerChannels().then((l) => {
+        setLedgerChannels(l);
+        if (l.length > 0) {
+          setFocusedLedgerChannel(l[0].ID);
+        }
+      });
     }
   }, [nitroClient]);
 
@@ -57,12 +45,10 @@ function App() {
       />
       <div style={{ display: "flex", justifyContent: "space-around" }}>
         <LedgerChannelDetails version={version} url={url} address={address} />
-        <PaymentChannelList
-          paymentChannels={paymentChannels}
-          focusedPaymentChannel={focusedPaymentChannel}
-          setFocusedPaymentChannel={setFocusedPaymentChannel}
+        <PaymentChannelContainer
+          nitroClient={nitroClient}
+          ledgerChannel={focusedLedgerChannel}
         />
-        <PaymentChannelDetails paymentChannel={focusedPaymentChannel} />
       </div>
     </>
   );

--- a/packages/site/src/components/LedgerChannelDetails.tsx
+++ b/packages/site/src/components/LedgerChannelDetails.tsx
@@ -1,25 +1,84 @@
-import { NetworkBalance } from "./NetworkBalance";
+import { NitroRpcClient } from "@statechannels/nitro-rpc-client";
+import { useEffect, useState } from "react";
+import { LedgerChannelBalance } from "@statechannels/nitro-rpc-client/src/types";
+
+import { NetworkBalance, VirtualChannelBalanceProps } from "./NetworkBalance";
+
+type Props = {
+  nitroClient: NitroRpcClient | null;
+  channelId: string;
+};
+
+type LedgerDetails = {
+  ledgerBalance: LedgerChannelBalance;
+  lockedBalances: VirtualChannelBalanceProps[];
+};
+
+async function getLedgerDetails(
+  nitroClient: NitroRpcClient,
+  channelId: string
+): Promise<LedgerDetails> {
+  const ledgerChannel = await nitroClient.GetLedgerChannel(channelId);
+  const paymentChannels = await nitroClient.GetPaymentChannelsByLedger(
+    channelId
+  );
+
+  // todo: remove this construction once big number over rpc is fixed
+  // At the moment, fields that are defined as big numbers are populated as numbers
+  const ledgerBalance = {
+    ...ledgerChannel.Balance,
+    ClientBalance: BigInt(ledgerChannel.Balance.ClientBalance),
+    HubBalance: BigInt(ledgerChannel.Balance.HubBalance),
+  };
+
+  const lockedBalances = paymentChannels.map((pc) => {
+    const total = pc.Balance.PaidSoFar + pc.Balance.RemainingFunds;
+    return {
+      // todo: this conversion should be removed once big number over rpc is fixed
+      budget: BigInt(total),
+      myPercentage: Number(pc.Balance.RemainingFunds / total),
+    };
+  });
+
+  return {
+    ledgerBalance,
+    lockedBalances,
+  };
+}
 
 export default function LedgerChannelDetails({
-  version,
-  url,
-  address,
-}: {
-  version: string;
-  url: string;
-  address: string;
-}) {
+  nitroClient,
+  channelId,
+}: Props) {
+  const [ledgerDetails, setLedgerDetails] = useState<LedgerDetails | null>(
+    null
+  );
+  const [myAddress, setMyAddress] = useState("");
+
+  useEffect(() => {
+    if (nitroClient && channelId != "") {
+      getLedgerDetails(nitroClient, channelId).then(setLedgerDetails);
+    }
+  }, [nitroClient, channelId]);
+
+  useEffect(() => {
+    if (nitroClient) {
+      nitroClient.GetAddress().then((a) => setMyAddress(a));
+    }
+  }, [nitroClient]);
+
+  const myBalance = ledgerDetails?.ledgerBalance.ClientBalance ?? BigInt(0);
+  const theirBalance = ledgerDetails?.ledgerBalance.HubBalance ?? BigInt(0);
+
   return (
     <div className="card">
+      <div> My Address: {myAddress}</div>
       <NetworkBalance
         status="running"
-        lockedBalances={[]}
-        myBalanceFree={BigInt(50)}
-        theirBalanceFree={BigInt(200)}
+        lockedBalances={ledgerDetails?.lockedBalances ?? []}
+        myBalanceFree={myBalance}
+        theirBalanceFree={theirBalance}
       ></NetworkBalance>
-      <p>Version: {version}</p>
-      <p> Url: {url}</p>
-      <p> Address: {address}</p>
     </div>
   );
 }

--- a/packages/site/src/components/LedgerChannelList.tsx
+++ b/packages/site/src/components/LedgerChannelList.tsx
@@ -16,7 +16,11 @@ function formatId(id: string): string {
 }
 
 function focusedIndex(id: string, ids: LedgerChannel[]): number {
-  return ids.findIndex((c) => c.ID === id);
+  const index = ids.findIndex((c) => c.ID === id);
+  if (index != -1) {
+    return index;
+  }
+  return 0;
 }
 
 function handleChange(

--- a/packages/site/src/components/LedgerChannelList.tsx
+++ b/packages/site/src/components/LedgerChannelList.tsx
@@ -20,6 +20,7 @@ function focusedIndex(id: string, ids: LedgerChannel[]): number {
   if (index != -1) {
     return index;
   }
+  // The channel id is not found in the channel list.
   return 0;
 }
 

--- a/packages/site/src/components/PaymentChannelContainer.tsx
+++ b/packages/site/src/components/PaymentChannelContainer.tsx
@@ -1,0 +1,44 @@
+import { NitroRpcClient } from "@statechannels/nitro-rpc-client";
+import { PaymentChannelInfo } from "@statechannels/nitro-rpc-client/src/types";
+import { useEffect, useState } from "react";
+
+import PaymentChannelList from "./PaymentChannelList";
+import PaymentChannelDetails from "./PaymentChannelDetails";
+
+type Props = {
+  nitroClient: NitroRpcClient | null;
+  ledgerChannel: string;
+};
+export default function PaymentChannelContainer({
+  nitroClient,
+  ledgerChannel,
+}: Props) {
+  const [paymentChannels, setPaymentChannels] = useState<PaymentChannelInfo[]>(
+    []
+  );
+
+  const [focusedPaymentChannel, setFocusedPaymentChannel] =
+    useState<string>("");
+
+  useEffect(() => {
+    if (nitroClient && ledgerChannel) {
+      nitroClient.GetPaymentChannelsByLedger(ledgerChannel).then((p) => {
+        setPaymentChannels(p);
+        if (p.length > 0) {
+          setFocusedPaymentChannel(p[0].ID);
+        }
+      });
+    }
+  }, [nitroClient, ledgerChannel]);
+
+  return (
+    <>
+      <PaymentChannelList
+        paymentChannels={paymentChannels}
+        focusedPaymentChannel={focusedPaymentChannel}
+        setFocusedPaymentChannel={setFocusedPaymentChannel}
+      />
+      <PaymentChannelDetails paymentChannel={focusedPaymentChannel} />
+    </>
+  );
+}

--- a/packages/site/src/components/PaymentChannelList.tsx
+++ b/packages/site/src/components/PaymentChannelList.tsx
@@ -1,19 +1,18 @@
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
-
-import { PaymentChannel } from "../types";
+import { PaymentChannelInfo } from "@statechannels/nitro-rpc-client/src/types";
 
 type Props = {
-  paymentChannels: PaymentChannel[];
+  paymentChannels: PaymentChannelInfo[];
   focusedPaymentChannel: string;
   setFocusedPaymentChannel: (channel: string) => void;
 };
 
-function formatPaymentChannel(chan: PaymentChannel): string {
+function formatPaymentChannel(chan: PaymentChannelInfo): string {
   return chan.ID.slice(0, 8);
 }
 
-function focusedIndex(id: string, ids: PaymentChannel[]): number {
+function focusedIndex(id: string, ids: PaymentChannelInfo[]): number {
   const index = ids.findIndex((c) => c.ID === id);
   if (index != -1) {
     return index;
@@ -23,7 +22,7 @@ function focusedIndex(id: string, ids: PaymentChannel[]): number {
 }
 
 function handleChange(
-  ledgerChannels: PaymentChannel[],
+  ledgerChannels: PaymentChannelInfo[],
   setter: (id: string) => void
 ) {
   return (_: React.SyntheticEvent, newValue: number) => {

--- a/packages/site/src/components/PaymentChannelList.tsx
+++ b/packages/site/src/components/PaymentChannelList.tsx
@@ -14,7 +14,12 @@ function formatPaymentChannel(chan: PaymentChannel): string {
 }
 
 function focusedIndex(id: string, ids: PaymentChannel[]): number {
-  return ids.findIndex((c) => c.ID === id);
+  const index = ids.findIndex((c) => c.ID === id);
+  if (index != -1) {
+    return index;
+  }
+  // The channel id is not found in the channel list.
+  return 0;
 }
 
 function handleChange(

--- a/packages/site/src/types.ts
+++ b/packages/site/src/types.ts
@@ -1,3 +1,0 @@
-export type PaymentChannel = {
-  ID: string;
-};


### PR DESCRIPTION
This PR populates the payment channel list view using the selected ledger channel instead of mock values.