### PR TITLE
Introduce `bootstrap` script and trigger `afterInstall`

### DIFF
--- a/.yarn/plugins/@yarnpkg/plugin-after-install.cjs
+++ b/.yarn/plugins/@yarnpkg/plugin-after-install.cjs
@@ -1,0 +1,9 @@
+/* eslint-disable */
+//prettier-ignore
+module.exports = {
+name: "@yarnpkg/plugin-after-install",
+factory: function (require) {
+var plugin=(()=>{var x=Object.create,i=Object.defineProperty;var k=Object.getOwnPropertyDescriptor;var C=Object.getOwnPropertyNames;var I=Object.getPrototypeOf,y=Object.prototype.hasOwnProperty;var h=t=>i(t,"__esModule",{value:!0});var n=t=>{if(typeof require!="undefined")return require(t);throw new Error('Dynamic require of "'+t+'" is not supported')};var w=(t,o)=>{for(var e in o)i(t,e,{get:o[e],enumerable:!0})},P=(t,o,e)=>{if(o&&typeof o=="object"||typeof o=="function")for(let r of C(o))!y.call(t,r)&&r!=="default"&&i(t,r,{get:()=>o[r],enumerable:!(e=k(o,r))||e.enumerable});return t},a=t=>P(h(i(t!=null?x(I(t)):{},"default",t&&t.__esModule&&"default"in t?{get:()=>t.default,enumerable:!0}:{value:t,enumerable:!0})),t);var A={};w(A,{default:()=>j});var g=a(n("@yarnpkg/core"));var c=a(n("@yarnpkg/core")),m={afterInstall:{description:"Hook that will always run after install",type:c.SettingsType.STRING,default:""}};var u=a(n("clipanion")),d=a(n("@yarnpkg/core"));var p=a(n("@yarnpkg/shell")),l=async(t,o)=>{var f;let e=t.get("afterInstall"),r=!!((f=t.projectCwd)==null?void 0:f.endsWith(`dlx-${process.pid}`));return e&&!r?(o&&console.log("Running `afterInstall` hook..."),(0,p.execute)(e,[],{cwd:t.projectCwd||void 0})):0};var s=class extends u.Command{async execute(){let o=await d.Configuration.find(this.context.cwd,this.context.plugins);return l(o,!1)}};s.paths=[["after-install"]];var b={configuration:m,commands:[s],hooks:{afterAllInstalled:async(t,o)=>{if((o==null?void 0:o.mode)===g.InstallMode.UpdateLockfile)return;if(await l(t.configuration,!0))throw new Error("The `afterInstall` hook failed, see output above.")}}},j=b;return A;})();
+return plugin;
+}
+};

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,4 +10,4 @@ plugins:
 
 yarnPath: .yarn/releases/yarn-3.5.1.cjs
 
-afterInstall: yarn workspaces foreach -pt run prepack
+afterInstall: yarn bootstrap

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,5 +5,9 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
+  - path: .yarn/plugins/@yarnpkg/plugin-after-install.cjs
+    spec: "https://raw.githubusercontent.com/mhassan1/yarn-plugin-after-install/v0.4.0/bundles/@yarnpkg/plugin-after-install.js"
 
 yarnPath: .yarn/releases/yarn-3.5.1.cjs
+
+afterInstall: yarn workspaces foreach -pt run prepack

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "yarn workspaces foreach -pt run build",
-    "lint": "yarn workspaces foreach -pt run lint"
+    "lint": "yarn workspaces foreach -pt run lint",
+    "bootstrap": "yarn workspaces foreach -pt run prepack"
   },
   "packageManager": "yarn@3.5.1"
 }

--- a/packages/nitro-rpc-client/package.json
+++ b/packages/nitro-rpc-client/package.json
@@ -8,11 +8,12 @@
   "main": "dist/src/index.js",
   "bin": "src/cli.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b .",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts --max-warnings 0",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
+    "prepack": "yarn build",
     "start": "npx ts-node src/cli.ts"
   },
   "dependencies": {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "yarn tsc -b && vite build",
+    "build": "vite build",
     "build-storybook": "storybook build",
     "dev": "vite",
     "lint": "eslint . --ext js,jsx,cjs,ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
This will meant that the `nitro-rpc-client` is built and ready to be used as a dependency straight away after installing the monorepo. After that, it should be straightforward to build/run the site or storybook with no more wrangling required.