### PR TITLE
Attach and throw websocket errors

### DIFF
--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -22,6 +22,13 @@ export class HttpTransport {
       new URL(`${rpcPath}/subscribe`, `ws://${server}`).toString(),
       undefined
     );
+
+    // throw any websocket errors so we don't fail silently
+    ws.onerror = (e) => {
+      console.error("Error with websocket connection to server");
+      throw e;
+    };
+
     // Wait for onopen to fire so we know the connection is ready
     await new Promise<void>((resolve) => (ws.onopen = () => resolve()));
 


### PR DESCRIPTION
Previously the nitro-rpc-client would fail silently if there was an error when attempting to connect via websocket. This PR updates the http transport to throw any websocket errors instead of silently failing, meaning we'll see what went wrong.