### PR TITLE
Use mock-socket to mock /api/subscribe

### DIFF
--- a/packages/site/.storybook/preview.ts
+++ b/packages/site/.storybook/preview.ts
@@ -1,8 +1,14 @@
 import type { Preview } from "@storybook/react";
 import { initialize, mswDecorator } from "msw-storybook-addon";
+import { WebSocket } from "mock-socket";
+
+// Override the global WebSocket object with the mock one
+global.WebSocket = WebSocket;
 
 // Initialize MSW
-initialize();
+initialize({
+  onUnhandledRequest: "bypass",
+});
 
 // Provide the MSW addon decorator globally
 export const decorators = [mswDecorator];

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
     "eslint-plugin-storybook": "^0.6.11",
+    "mock-socket": "^9.2.1",
     "msw": "^1.2.1",
     "msw-storybook-addon": "^1.8.0",
     "prop-types": "^15.8.1",

--- a/packages/site/src/App.stories.tsx
+++ b/packages/site/src/App.stories.tsx
@@ -1,5 +1,7 @@
 import { rest } from "msw";
 import { Meta } from "@storybook/react";
+import { Server } from "mock-socket";
+import { useEffect } from "react";
 
 import App from "./App";
 import {
@@ -9,12 +11,32 @@ import {
   getPaymentChannelsByLedgerMock,
 } from "./mocks/request";
 
+function createMockServer() {
+  const mockServer = new Server("ws://localhost:4005/api/subscribe");
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  mockServer.on("connection", () => {});
+  return mockServer;
+}
+
 const meta: Meta<typeof App> = {
   title: "App",
   component: App,
 };
+
 export default meta;
-export const AppPopulated = () => <App />;
+export const AppPopulated = () => {
+  const mockServer = createMockServer();
+
+  // Clean up after the story is unmounted
+  useEffect(() => {
+    return () => {
+      mockServer.stop();
+    };
+  }, [mockServer]);
+
+  return <App />;
+};
+
 AppPopulated.parameters = {
   msw: {
     handlers: [

--- a/packages/site/src/App.stories.tsx
+++ b/packages/site/src/App.stories.tsx
@@ -13,8 +13,6 @@ import {
 
 function createMockServer() {
   const mockServer = new Server("ws://localhost:4005/api/subscribe");
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  mockServer.on("connection", () => {});
   return mockServer;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9460,6 +9460,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mock-socket@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "mock-socket@npm:9.2.1"
+  checksum: daf07689563163dbcefbefe23b2a9784a75d0af31706f23ad535c6ab2abbcdefa2e91acddeb50a3c39009139e47a8f909cbb38e8137452193ccb9331637fee3e
+  languageName: node
+  linkType: hard
+
 "mri@npm:^1.2.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
@@ -11357,6 +11364,7 @@ __metadata:
     eslint-plugin-react-refresh: ^0.3.4
     eslint-plugin-storybook: ^0.6.11
     js-big-decimal-esm: ^1.5.1
+    mock-socket: ^9.2.1
     msw: ^1.2.1
     msw-storybook-addon: ^1.8.0
     prop-types: ^15.8.1


### PR DESCRIPTION
The `App` component initializes an http nitro client. The nitro client establishes a websocket connection to a nitro node. In storybook, we do not expect a running nitro node. This PR uses `mock-socket` to avoid a client error on websocket connection creation.

Note that this enables us to run storybook locally without a running nitro node. On Netlify, the App story is still not working for other reasons.