### PR TITLE
Update nitro client to use new jsonrpc api/v1 endpoint

### DIFF
--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -11,7 +11,7 @@ import {
 
 import { Transport } from ".";
 
-export const RPC_PATH = "api";
+export const RPC_PATH = "api/v1";
 
 export class HttpTransport {
   Notifications: EventEmitter<NotificationMethod, NotificationPayload>;

--- a/packages/site/src/App.stories.tsx
+++ b/packages/site/src/App.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from "./mocks/request";
 
 function createMockServer() {
-  const mockServer = new Server("ws://localhost:4005/api/subscribe");
+  const mockServer = new Server("ws://localhost:4005/api/v1/subscribe");
   return mockServer;
 }
 
@@ -38,7 +38,7 @@ export const AppPopulated = () => {
 AppPopulated.parameters = {
   msw: {
     handlers: [
-      rest.post("http://localhost:4005/api", async (req, res, ctx) => {
+      rest.post("http://localhost:4005/api/v1", async (req, res, ctx) => {
         const json = await req.json();
         let retVal = {};
         switch (json.method) {


### PR DESCRIPTION
The format of the go-nitro jsonrpc server's endpoint will change with this [go-nitro PR](https://github.com/statechannels/go-nitro/pull/1336). Therefore we need to change the way requests are formed by the nitro-rpc-client in this repo

### Notes
I am not exactly sure what the GUI is supposed to look like so might need someone to help me verify this is working as expected.