### PR TITLE
Refetch ledger channels on notifications

### DIFF
--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -8,6 +8,13 @@ import { QUERY_KEY } from "./constants";
 import LedgerChannelDetails from "./components/LedgerChannelDetails";
 import PaymentChannelContainer from "./components/PaymentChannelContainer";
 
+async function fetchLedgerChannels(
+  nitroClient: NitroRpcClient,
+  setLedgerChannels: (l: LedgerChannelInfo[]) => void
+) {
+  setLedgerChannels(await nitroClient.GetAllLedgerChannels());
+}
+
 function App() {
   const url =
     new URLSearchParams(window.location.search).get(QUERY_KEY) ??
@@ -22,14 +29,19 @@ function App() {
 
   useEffect(() => {
     if (nitroClient) {
-      nitroClient.GetAllLedgerChannels().then((l) => {
-        setLedgerChannels(l);
-        if (l.length > 0) {
-          setFocusedLedgerChannel(l[0].ID);
-        }
-      });
+      fetchLedgerChannels(nitroClient, setLedgerChannels);
+      nitroClient?.Notifications.on("objective_completed", () =>
+        fetchLedgerChannels(nitroClient, setLedgerChannels)
+      );
     }
   }, [nitroClient]);
+
+  const focusedChannelInLedgerChannels = ledgerChannels.some(
+    (lc) => lc.ID === focusedLedgerChannel
+  );
+  if (!focusedChannelInLedgerChannels && ledgerChannels.length > 0) {
+    setFocusedLedgerChannel(ledgerChannels[0].ID);
+  }
 
   return (
     <>

--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -8,7 +8,7 @@ import { QUERY_KEY } from "./constants";
 import LedgerChannelDetails from "./components/LedgerChannelDetails";
 import PaymentChannelContainer from "./components/PaymentChannelContainer";
 
-async function fetchLedgerChannels(
+async function fetchAndSetLedgerChannels(
   nitroClient: NitroRpcClient,
   setLedgerChannels: (l: LedgerChannelInfo[]) => void
 ) {
@@ -29,9 +29,9 @@ function App() {
 
   useEffect(() => {
     if (nitroClient) {
-      fetchLedgerChannels(nitroClient, setLedgerChannels);
+      fetchAndSetLedgerChannels(nitroClient, setLedgerChannels);
       nitroClient?.Notifications.on("objective_completed", () =>
-        fetchLedgerChannels(nitroClient, setLedgerChannels)
+        fetchAndSetLedgerChannels(nitroClient, setLedgerChannels)
       );
     }
   }, [nitroClient]);


### PR DESCRIPTION
This PR wires up objective completed notifications to the UI. On receiving an objective completed notification, the UI refetches ledger channels. If a ledger channel is in focus and the ledger channel is in the returned ledger channel list, the ledger channel remains in focus.

Testing notifications is a manual process. `client-runner` has been modified for ease of testing:
1. Run `rm -rf data && go run ./scripts/start-rpc-servers.go` in the root directory of the `go-nitro` repo.
2. Run `yarn dev` in `site` package of this repo.
3. Load http://localhost:5173/
4. Create a ledger channel using either the `create-ledger` or `create-channels` command in `nitro-rpc-client` of this repo. For example, `npx ts-node ./scripts/client-runner.ts create-ledger --left alice --right bob`.
5. Observe updates in the UI.