### PR TITLE
Require full url path (inc. api/vx) when creating NitroRpcClient

### DIFF
--- a/packages/nitro-rpc-client/readme.md
+++ b/packages/nitro-rpc-client/readme.md
@@ -10,7 +10,7 @@ import { NitroRpcClient } from "./rpc-client";
 const rpcPort = 4222;
 
 const rpcClient = await NitroRpcClient.CreateHttpRpcClient(
-  `127.0.0.1:${rpcPort}`
+  `127.0.0.1:${rpcPort}/api/v1`
 );
 
 const counterParty = `0xDEADBEEF`;

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -12,7 +12,6 @@ import {
   getLocalRPCUrl,
   logOutChannelUpdates,
 } from "../src/utils";
-import { RPC_PATH } from "../src/transport/http";
 
 const clientNames = ["alice", "irene", "bob", "ivan"] as const;
 type ClientNames = (typeof clientNames)[number];
@@ -287,10 +286,7 @@ async function waitForRPCServer(
 // This is specific to the HTTP/WS RPC transport
 async function isServerUp(port: number): Promise<boolean> {
   let result: AxiosResponse<unknown, unknown>;
-  const url = new URL(
-    `${RPC_PATH}`,
-    `http://${getLocalRPCUrl(port)}`
-  ).toString();
+  const url = new URL(`http://${getLocalRPCUrl(port)}`).toString();
 
   try {
     const req = generateRequest("get_address", {});

--- a/packages/nitro-rpc-client/src/transport/http.ts
+++ b/packages/nitro-rpc-client/src/transport/http.ts
@@ -11,17 +11,12 @@ import {
 
 import { Transport } from ".";
 
-export const RPC_PATH = "api/v1";
-
 export class HttpTransport {
   Notifications: EventEmitter<NotificationMethod, NotificationPayload>;
 
   public static async createTransport(server: string): Promise<Transport> {
     // eslint-disable-next-line new-cap
-    const ws = new w3cwebsocket(
-      new URL(`${RPC_PATH}/subscribe`, `ws://${server}`).toString(),
-      undefined
-    );
+    const ws = new w3cwebsocket(`ws://${server}/subscribe`, undefined);
 
     // throw any websocket errors so we don't fail silently
     ws.onerror = (e) => {
@@ -39,7 +34,7 @@ export class HttpTransport {
   public async sendRequest<K extends RequestMethod>(
     req: RPCRequestAndResponses[K][0]
   ): Promise<unknown> {
-    const url = new URL(`${RPC_PATH}`, `http://${this.server}`).toString();
+    const url = new URL(`http://${this.server}`).toString();
 
     const result = await axios.post(url.toString(), JSON.stringify(req));
 

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -7,6 +7,8 @@ import {
   RPCRequestAndResponses,
 } from "./types";
 
+export const RPC_PATH = "api/v1";
+
 /**
  * createOutcome creates a basic outcome for a channel
  *
@@ -83,7 +85,7 @@ export function generateRequest<
 }
 
 export function getLocalRPCUrl(port: number): string {
-  return `127.0.0.1:${port}`;
+  return `127.0.0.1:${port}/${RPC_PATH}`;
 }
 
 export async function logOutChannelUpdates(rpcClient: NitroRpcClient) {

--- a/packages/site/src/App.tsx
+++ b/packages/site/src/App.tsx
@@ -18,7 +18,7 @@ async function fetchAndSetLedgerChannels(
 function App() {
   const url =
     new URLSearchParams(window.location.search).get(QUERY_KEY) ??
-    "localhost:4005";
+    "localhost:4005/api/v1";
   const [nitroClient, setNitroClient] = useState<NitroRpcClient | null>(null);
   const [ledgerChannels, setLedgerChannels] = useState<LedgerChannelInfo[]>([]);
   const [focusedLedgerChannel, setFocusedLedgerChannel] = useState<string>("");


### PR DESCRIPTION
Removes hardcoded `api/v1` RPC_PATH variable from client code. Instead, the full jsonrpc server path should be provided when creating a new NitroRpcClient instance. This aligns with the golang nitro rpc client implementation.

Addresses these comments: https://github.com/statechannels/boost/pull/14/files#r1238779295