### PR TITLE
Update TS client to match go client and new rpc server methods

### DIFF
--- a/packages/nitro-rpc-client/package.json
+++ b/packages/nitro-rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statechannels/nitro-rpc-client",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Typescript RPC client for go-nitro",
   "repository": "https://github.com/statechannels/nitro-rpc-client.git",
   "license": "MIT",

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -162,7 +162,9 @@ yargs(hideBin(process.argv))
       const virtualChannels: string[] = [];
       console.log(`Constructing ${yargs.numvirtual} virtual channels`);
       for (let i = 0; i < yargs.numvirtual; i++) {
-        const res = await aliceClient.CreatePaymentChannel(bobAddress, [ireneAddress]);
+        const res = await aliceClient.CreatePaymentChannel(bobAddress, [
+          ireneAddress,
+        ]);
         console.log(`Virtual channel ${res.ChannelId} created`);
         virtualChannels.push(res.ChannelId);
       }

--- a/packages/nitro-rpc-client/scripts/client-runner.ts
+++ b/packages/nitro-rpc-client/scripts/client-runner.ts
@@ -149,10 +149,10 @@ yargs(hideBin(process.argv))
       if (yargs.createledgers) {
         // Setup ledger channels
         console.log("Constructing ledger channels");
-        const aliceLedger = await aliceClient.DirectFund(ireneAddress);
+        const aliceLedger = await aliceClient.CreateLedgerChannel(ireneAddress);
         console.log(`Ledger channel ${aliceLedger.ChannelId} created`);
 
-        const bobLedger = await ireneClient.DirectFund(bobAddress);
+        const bobLedger = await ireneClient.CreateLedgerChannel(bobAddress);
         console.log(`Ledger channel ${bobLedger.ChannelId} created`);
 
         await wait(1000);
@@ -162,7 +162,7 @@ yargs(hideBin(process.argv))
       const virtualChannels: string[] = [];
       console.log(`Constructing ${yargs.numvirtual} virtual channels`);
       for (let i = 0; i < yargs.numvirtual; i++) {
-        const res = await aliceClient.VirtualFund(bobAddress, [ireneAddress]);
+        const res = await aliceClient.CreatePaymentChannel(bobAddress, [ireneAddress]);
         console.log(`Virtual channel ${res.ChannelId} created`);
         virtualChannels.push(res.ChannelId);
       }
@@ -186,7 +186,7 @@ yargs(hideBin(process.argv))
           break;
         }
 
-        const res = await aliceClient.VirtualDefund(channelId);
+        const res = await aliceClient.ClosePaymentChannel(channelId);
         console.log(
           `Virtual channel ${getChannelIdFromObjectiveId(res)} closed`
         );
@@ -233,7 +233,7 @@ yargs(hideBin(process.argv))
 
       // Setup ledger channels
       console.log("Constructing ledger channels");
-      const ledger = await leftClient.DirectFund(rightAddress);
+      const ledger = await leftClient.CreateLedgerChannel(rightAddress);
       console.log(`Ledger channel ${ledger.ChannelId} created`);
 
       await wait(1000);

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -115,7 +115,9 @@ yargs(hideBin(process.argv))
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
-      const dfObjective = await rpcClient.CreateLedgerChannel(yargs.counterparty);
+      const dfObjective = await rpcClient.CreateLedgerChannel(
+        yargs.counterparty
+      );
       const { Id } = dfObjective;
 
       console.log(`Objective started ${Id}`);

--- a/packages/nitro-rpc-client/src/cli.ts
+++ b/packages/nitro-rpc-client/src/cli.ts
@@ -115,7 +115,7 @@ yargs(hideBin(process.argv))
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
-      const dfObjective = await rpcClient.DirectFund(yargs.counterparty);
+      const dfObjective = await rpcClient.CreateLedgerChannel(yargs.counterparty);
       const { Id } = dfObjective;
 
       console.log(`Objective started ${Id}`);
@@ -143,7 +143,7 @@ yargs(hideBin(process.argv))
       );
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
-      const id = await rpcClient.DirectDefund(yargs.channelId);
+      const id = await rpcClient.CloseLedgerChannel(yargs.channelId);
       console.log(`Objective started ${id}`);
       await rpcClient.WaitForObjective(id);
       console.log(`Objective complete ${id}`);
@@ -180,7 +180,7 @@ yargs(hideBin(process.argv))
           return intermediary.toString(16);
         }) ?? [];
 
-      const vfObjective = await rpcClient.VirtualFund(
+      const vfObjective = await rpcClient.CreatePaymentChannel(
         yargs.counterparty,
         intermediaries
       );
@@ -212,7 +212,7 @@ yargs(hideBin(process.argv))
 
       if (yargs.n) logOutChannelUpdates(rpcClient);
 
-      const id = await rpcClient.VirtualDefund(yargs.channelId);
+      const id = await rpcClient.ClosePaymentChannel(yargs.channelId);
 
       console.log(`Objective started ${id}`);
       await rpcClient.WaitForObjective(id);

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -48,7 +48,9 @@ export class NitroRpcClient {
    * @param counterParty - The counterparty to create the channel with
    * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
    */
-  public async CreateLedgerChannel(counterParty: string): Promise<ObjectiveResponse> {
+  public async CreateLedgerChannel(
+    counterParty: string
+  ): Promise<ObjectiveResponse> {
     const asset = `0x${"00".repeat(20)}`;
     const params: DirectFundParams = {
       CounterParty: counterParty,

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -69,7 +69,7 @@ export class NitroRpcClient {
   }
 
   /**
-   * CreatePaymentChannel creates a virtually funded channel with the counterparty, using the given intermediaries.
+   * CreatePaymentChannel creates a virtually funded payment channel with the counterparty, using the given intermediaries.
    *
    * @param counterParty - The counterparty to create the channel with
    * @param intermediaries - The intermerdiaries to use

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -43,12 +43,12 @@ export class NitroRpcClient {
   }
 
   /**
-   * DirectFund creates a directly funded ledger channel with the counterparty.
+   * CreateLedgerChannel creates a directly funded ledger channel with the counterparty.
    *
    * @param counterParty - The counterparty to create the channel with
    * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
    */
-  public async DirectFund(counterParty: string): Promise<ObjectiveResponse> {
+  public async CreateLedgerChannel(counterParty: string): Promise<ObjectiveResponse> {
     const asset = `0x${"00".repeat(20)}`;
     const params: DirectFundParams = {
       CounterParty: counterParty,
@@ -63,17 +63,17 @@ export class NitroRpcClient {
       AppData: "0x00",
       Nonce: Date.now(),
     };
-    return this.sendRequest("direct_fund", params);
+    return this.sendRequest("create_ledger_channel", params);
   }
 
   /**
-   * VirtualFund creates a virtually funded channel with the counterparty, using the given intermediaries.
+   * CreatePaymentChannel creates a virtually funded channel with the counterparty, using the given intermediaries.
    *
    * @param counterParty - The counterparty to create the channel with
    * @param intermediaries - The intermerdiaries to use
    * @returns A promise that resolves to an objective response, containing the ID of the objective and the channel id.
    */
-  public async VirtualFund(
+  public async CreatePaymentChannel(
     counterParty: string,
     intermediaries: string[]
   ): Promise<ObjectiveResponse> {
@@ -92,7 +92,7 @@ export class NitroRpcClient {
       Nonce: Date.now(),
     };
 
-    return this.sendRequest("virtual_fund", params);
+    return this.sendRequest("create_payment_channel", params);
   }
 
   /**
@@ -112,25 +112,25 @@ export class NitroRpcClient {
   }
 
   /**
-   * DirectDefund defunds a directly funded ledger channel.
+   * CloseLedgerChannel defunds a directly funded ledger channel.
    *
    * @param channelId - The ID of the channel to defund
    * @returns The ID of the objective that was created
    */
-  public async DirectDefund(channelId: string): Promise<string> {
+  public async CloseLedgerChannel(channelId: string): Promise<string> {
     const params: DefundObjectiveRequest = { ChannelId: channelId };
-    return this.sendRequest("direct_defund", params);
+    return this.sendRequest("close_ledger_channel", params);
   }
   /**
-   * VirtualDefund defunds a virtually funded payment channel.
+   * ClosePaymentChannel defunds a virtually funded payment channel.
    *
    * @param channelId - The ID of the channel to defund
    * @returns The ID of the objective that was created
    */
 
-  public async VirtualDefund(channelId: string): Promise<string> {
+  public async ClosePaymentChannel(channelId: string): Promise<string> {
     const params: DefundObjectiveRequest = { ChannelId: channelId };
-    return this.sendRequest("virtual_defund", params);
+    return this.sendRequest("close_payment_channel", params);
   }
 
   /**

--- a/packages/nitro-rpc-client/src/serde.ts
+++ b/packages/nitro-rpc-client/src/serde.ts
@@ -120,17 +120,17 @@ export function getAndValidateResult<T extends RequestMethod>(
 ): RPCRequestAndResponses[T][1]["result"] {
   const result = getJsonRpcResult(response);
   switch (method) {
-    case "direct_fund":
-    case "virtual_fund":
+    case "create_ledger_channel":
+    case "create_payment_channel":
       return validateAndConvertResult(
         objectiveSchema,
         result,
         (result: ObjectiveSchemaType) => result
       );
-    case "direct_defund":
+    case "close_ledger_channel":
     case "version":
     case "get_address":
-    case "virtual_defund":
+    case "close_payment_channel":
       return validateAndConvertResult(
         stringSchema,
         result,

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -77,10 +77,7 @@ export type DirectFundRequest = JsonRpcRequest<
   "create_ledger_channel",
   DirectFundParams
 >;
-export type PaymentRequest = JsonRpcRequest<
-  "pay", 
-  PaymentParams
->;
+export type PaymentRequest = JsonRpcRequest<"pay", PaymentParams>;
 export type VirtualFundRequest = JsonRpcRequest<
   "create_payment_channel",
   VirtualFundParams
@@ -102,10 +99,7 @@ export type GetPaymentChannelsByLedgerRequest = JsonRpcRequest<
   GetByLedgerRequest
 >;
 
-export type VersionRequest = JsonRpcRequest<
-  "version",
-  Record<string, never>
->;
+export type VersionRequest = JsonRpcRequest<"version", Record<string, never>>;
 export type DirectDefundRequest = JsonRpcRequest<
   "close_ledger_channel",
   DefundObjectiveRequest

--- a/packages/nitro-rpc-client/src/types.ts
+++ b/packages/nitro-rpc-client/src/types.ts
@@ -73,10 +73,16 @@ export type GetAddressRequest = JsonRpcRequest<
   "get_address",
   Record<string, never>
 >;
-export type DirectFundRequest = JsonRpcRequest<"direct_fund", DirectFundParams>;
-export type PaymentRequest = JsonRpcRequest<"pay", PaymentParams>;
+export type DirectFundRequest = JsonRpcRequest<
+  "create_ledger_channel",
+  DirectFundParams
+>;
+export type PaymentRequest = JsonRpcRequest<
+  "pay", 
+  PaymentParams
+>;
 export type VirtualFundRequest = JsonRpcRequest<
-  "virtual_fund",
+  "create_payment_channel",
   VirtualFundParams
 >;
 export type GetLedgerChannelRequest = JsonRpcRequest<
@@ -96,13 +102,16 @@ export type GetPaymentChannelsByLedgerRequest = JsonRpcRequest<
   GetByLedgerRequest
 >;
 
-export type VersionRequest = JsonRpcRequest<"version", Record<string, never>>;
+export type VersionRequest = JsonRpcRequest<
+  "version",
+  Record<string, never>
+>;
 export type DirectDefundRequest = JsonRpcRequest<
-  "direct_defund",
+  "close_ledger_channel",
   DefundObjectiveRequest
 >;
 export type VirtualDefundRequest = JsonRpcRequest<
-  "virtual_defund",
+  "close_payment_channel",
   DefundObjectiveRequest
 >;
 
@@ -128,15 +137,15 @@ export type GetPaymentChannelsByLedgerResponse = JsonRpcResponse<
  * This is a map of all the RPC methods to their request and response types
  */
 export type RPCRequestAndResponses = {
-  direct_fund: [DirectFundRequest, DirectFundResponse];
-  direct_defund: [DirectDefundRequest, DirectDefundResponse];
+  create_ledger_channel: [DirectFundRequest, DirectFundResponse];
+  close_ledger_channel: [DirectDefundRequest, DirectDefundResponse];
   version: [VersionRequest, VersionResponse];
-  virtual_fund: [VirtualFundRequest, VirtualFundResponse];
+  create_payment_channel: [VirtualFundRequest, VirtualFundResponse];
   get_address: [GetAddressRequest, GetAddressResponse];
   get_ledger_channel: [GetLedgerChannelRequest, GetLedgerChannelResponse];
   get_payment_channel: [GetPaymentChannelRequest, GetPaymentChannelResponse];
   pay: [PaymentRequest, PaymentResponse];
-  virtual_defund: [VirtualDefundRequest, VirtualDefundResponse];
+  close_payment_channel: [VirtualDefundRequest, VirtualDefundResponse];
   get_all_ledger_channels: [
     GetAllLedgerChannelsRequest,
     GetAllLedgerChannelsResponse


### PR DESCRIPTION
Since we are renaming the jsonrpc methods provided by the go-nitro server, we need to update the client to match.

This should be coordinated with the go-nitro updates: https://github.com/statechannels/go-nitro/pull/1368