### PR TITLE
Update nitro rpc client to properly handle objective complete

### DIFF
--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -31,14 +31,11 @@ export class NitroRpcClient {
    */
   public async WaitForObjective(objectiveId: string): Promise<void> {
     return new Promise((resolve) => {
-      this.transport.Notifications.addListener(
-        "objective_completed",
-        (notif) => {
-          if (notif.params === objectiveId) {
-            resolve();
-          }
+      this.transport.Notifications.on("objective_completed", (notif) => {
+        if (notif.params === objectiveId) {
+          resolve();
         }
-      );
+      });
     });
   }
 

--- a/packages/nitro-rpc-client/src/rpc-client.ts
+++ b/packages/nitro-rpc-client/src/rpc-client.ts
@@ -8,6 +8,7 @@ import {
   RequestMethod,
   RPCRequestAndResponses,
   ObjectiveResponse,
+  ObjectiveCompleteNotification,
 } from "./types";
 import { Transport } from "./transport";
 import { createOutcome, generateRequest } from "./utils";
@@ -31,11 +32,14 @@ export class NitroRpcClient {
    */
   public async WaitForObjective(objectiveId: string): Promise<void> {
     return new Promise((resolve) => {
-      this.transport.Notifications.on("objective_completed", (notif) => {
-        if (notif.params === objectiveId) {
-          resolve();
+      this.transport.Notifications.on(
+        "objective_completed",
+        (params: ObjectiveCompleteNotification["params"]) => {
+          if (params === objectiveId) {
+            resolve();
+          }
         }
-      });
+      );
     });
   }
 

--- a/packages/nitro-rpc-client/src/utils.ts
+++ b/packages/nitro-rpc-client/src/utils.ts
@@ -91,7 +91,7 @@ export function getLocalRPCUrl(port: number): string {
 export async function logOutChannelUpdates(rpcClient: NitroRpcClient) {
   const shortAddress = (await rpcClient.GetAddress()).slice(0, 8);
 
-  rpcClient.Notifications.addListener(
+  rpcClient.Notifications.on(
     "ledger_channel_updated",
     (info: LedgerChannelInfo) => {
       console.log(
@@ -99,7 +99,7 @@ export async function logOutChannelUpdates(rpcClient: NitroRpcClient) {
       );
     }
   );
-  rpcClient.Notifications.addListener(
+  rpcClient.Notifications.on(
     "payment_channel_updated",
     (info: PaymentChannelInfo) => {
       console.log(


### PR DESCRIPTION
Fixes #81 

This PR makes two changes:
- Switches our calls of  `addListener` to `on`.  addListener is just syntactic sugar for `on` [defined by ethers](https://github.com/ethers-io/ethers.js/blob/d2b5f1da025cfaf62ebcac2929c7a48cfbcef572/src.ts/utils/events.ts#L63)
- Updates the objective complete handler to correctly handle the notification payload. 